### PR TITLE
feat: Add brand logo to page header

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -8,9 +8,12 @@ const Hero = () => {
       <div className="absolute inset-0 bg-black/10"></div>
       <div className="container mx-auto px-4 relative z-10">
         <div className="max-w-4xl mx-auto text-center">
-          <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold mb-6 leading-tight">
-            <span className="text-cyan-400">ZeeIT</span> Solutions
-          </h1>
+          <div className="flex items-center justify-center mb-6">
+            <img src="/logo.png" alt="ZeeIT Solutions Logo" className="h-20 mr-4" />
+            <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold leading-tight">
+              <span className="text-cyan-400">ZeeIT</span> Solutions
+            </h1>
+          </div>
           <p className="text-xl md:text-2xl lg:text-3xl mb-8 text-gray-200 font-light">
             Empowering Businesses with Scalable Software Solutions
           </p>


### PR DESCRIPTION
- Added the company logo (`public/logo.png`) to the `Hero` component.
- The logo is displayed to the left of the main title ("ZeeIT Solutions").
- Styled the logo and title to be centered horizontally on the page using flexbox.
- Adjusted logo size to h-20 (80px) for better visual balance.